### PR TITLE
1.3.1 b)

### DIFF
--- a/chapters/chapter1/chapter1-3.tex
+++ b/chapters/chapter1/chapter1-3.tex
@@ -11,13 +11,13 @@
   \enum{
   \item We have $i = \inf A$ if and only if
     \enumr{
-      \item Lower bound, $a \ge i$ forall $a \in A$
+      \item Lower bound, $a \ge i$ for all $a \in A$
       \item Greatest lower bound, If $b$ is a lower bound on $A$ then $b \le i$
     }
-  \item Suppose $i$ is a lower bound for $A$, it is the greatest lower bound if and only if forall $\epsilon>0$, there exists an $a\in A$ such that $i + \epsilon < a$. \par
-    First suppose $i = \inf A$, then forall $\epsilon > 0$, $i+\epsilon$ cannot be a lower bound on $A$ because (ii) implies all lower bounds $b$ obey $b \le i$, but $i+\epsilon > i$ so it can't be a lower bound.
+  \item Suppose $i$ is a lower bound for $A$, it is the greatest lower bound if and only if for all $\epsilon>0$, there exists an $a\in A$ such that $i + \epsilon > a$. \par
+    First suppose $i = \inf A$, then for all $\epsilon > 0$, $i+\epsilon$ cannot be a lower bound on $A$ because (ii) implies all lower bounds $b$ obey $b \le i$, therefore there must be some $a \in A$ such that $i+\epsilon > a$.
 
-    Second suppose forall $\epsilon > 0$ there exists an $a \in A$ such that $i+\epsilon < a$ to show (ii). In other words $i+\epsilon$ is not a lower bound for all $\epsilon$, which is the same as saying every lower bound $b$ must have $b \le i$ implying (ii).
+    Second suppose for all $\epsilon > 0$ there exists an $a \in A$ such that $i+\epsilon > a$. In other words $i+\epsilon$ is not a lower bound for all $\epsilon$, which is the same as saying every lower bound $b$ must have $b \le i$ implying (ii).
   }
 \end{solution}
 


### PR DESCRIPTION
I believe there's an error in the solution to 1.3.1 b). Original question was to define and prove a lemma like Lemma 1.3.8 but for the infimum. 

The current solution:
![image](https://user-images.githubusercontent.com/24727586/165466991-e1435f7b-201a-45c3-a7bc-c19d51f7359c.png)

But I'm pretty sure this is wrong; just take A = {0}, i = 0 (which is obviously the infimum of A), but epsilon = 1 leaves you with i+epsilon = 1, with no value of a in A such that i + epsilon = 1 < a 

Pretty sure the correct lemma also reverses the inequality direction; this has impacts on the proof of the lemma in some cases.

Also changed `forall` to `for all` while I was here
