### PR TITLE
Changes to 1.4

### DIFF
--- a/chapters/chapter1/chapter1-4.tex
+++ b/chapters/chapter1/chapter1-4.tex
@@ -123,7 +123,7 @@
       \item $\bigcap_{n=1}^\infty J_n = \bigcap_{n=1}^\infty\left(\bigcap_{k=1}^n I_k\right) = \bigcap_{n=1}^\infty I_n$
     }
 
-    By (i), (ii) and (iii) the Nested Interval Property tells us $\bigcap_{n=1}^\infty J_n \ne \emptyset$. Therefor by (iv) $\bigcap_{n=1}^\infty I_n \ne \emptyset$.
+    By (i), (ii) and (iii) the Nested Interval Property tells us $\bigcap_{n=1}^\infty J_n \ne \emptyset$. Therefore by (iv) $\bigcap_{n=1}^\infty I_n \ne \emptyset$.
   }
 \end{solution}
 

--- a/chapters/chapter1/chapter1-4.tex
+++ b/chapters/chapter1/chapter1-4.tex
@@ -110,7 +110,10 @@
 \begin{solution}
   \enum{
   \item $A = \mathbf{Q} \cap (0, 1)$, $B = \mathbf{I} \cap (0, 1)$. $A \cap B = \emptyset$, $\sup A = \sup B = 1$ and $1 \notin A$, $1 \notin B$.
-  \item Impossible. $\bigcap_{n=1}^\infty J_n$ is the same as asking what happens to $J_n$ as $n$ goes to $\infty$. since every $J_n$ is nonempty, $\bigcap_{n=1}^\infty = J_\infty$ must have an uncountably infinite number of elements.
+  \item Defining $J_i = (a_i, b_i)$, $A = \{a_n : n \in \mathbf{N}\}$, $B = \{b_n : n \in \mathbf{N}\}$, $\bigcap_{n=1}^\infty J_n$ will at least contain $(\sup A, \inf B)$. Thus, a necessary condition to meet the request is $\sup A = \inf B$.
+
+  $J_i = (-2^{-i}, 2^{-i})$ satisfies this condition ($\sup A = \inf B = 0$) and by inspection, $\bigcap_{n=1}^\infty J_n = \{0\}$, which meets the request.
+
   \item $L_n = [n, \infty)$ has $\bigcap_{n=1}^\infty L_n = \emptyset$
   \item Impossible. Let $J_n = \bigcap_{k=1}^n I_k$ and observe the following
     \enumr{

--- a/chapters/chapter1/chapter1-4.tex
+++ b/chapters/chapter1/chapter1-4.tex
@@ -73,7 +73,7 @@
 
 \begin{solution}
   \enum{
-  \item Dense.
+  \item Not dense since we cannot make $|p|/q$ smaller then $1/10$.
   \item Dense.
   \item Not dense since we cannot make $|p|/q$ smaller then $1/10$.
   }

--- a/chapters/chapter1/chapter1-4.tex
+++ b/chapters/chapter1/chapter1-4.tex
@@ -112,7 +112,7 @@
   \item $A = \mathbf{Q} \cap (0, 1)$, $B = \mathbf{I} \cap (0, 1)$. $A \cap B = \emptyset$, $\sup A = \sup B = 1$ and $1 \notin A$, $1 \notin B$.
   \item Defining $J_i = (a_i, b_i)$, $A = \{a_n : n \in \mathbf{N}\}$, $B = \{b_n : n \in \mathbf{N}\}$, $\bigcap_{n=1}^\infty J_n$ will at least contain $(\sup A, \inf B)$. Thus, a necessary condition to meet the request is $\sup A = \inf B$.
 
-  $J_i = (-2^{-i}, 2^{-i})$ satisfies this condition ($\sup A = \inf B = 0$) and by inspection, $\bigcap_{n=1}^\infty J_n = \{0\}$, which meets the request.
+  $J_i = (-1/n, 1/n)$ satisfies this condition ($\sup A = \inf B = 0$) and by inspection, $\bigcap_{n=1}^\infty J_n = \{0\}$, which meets the request.
 
   \item $L_n = [n, \infty)$ has $\bigcap_{n=1}^\infty L_n = \emptyset$
   \item Impossible. Let $J_n = \bigcap_{k=1}^n I_k$ and observe the following

--- a/chapters/chapter1/chapter1-5.tex
+++ b/chapters/chapter1/chapter1-5.tex
@@ -174,7 +174,7 @@
 \begin{solution}
   \enum{
   \item We scale and shift up into the square. $f(x) = \frac 12 x + \frac 13$
-  \item Let $g : S \to (0, 1)$ be a function that interleaves decimals in the representation without trailing nines. $g(0.32, 0.45) = 0.3425$ and $g(0.1\bar 9, 0.2) = g(0.2, 0.2) = 0.22$ etc.
+  \item Let $g : S \to (0, 1)$ be a function that interleaves decimals in the representation without trailing nines, padding with zeros if necessary. $g(0.32, 0.45) = 0.3425$, $g(0.1\bar 9, 0.2) = g(0.2, 0.2) = 0.22$, $g(0.1, 0.23) = 0.1203$, $g(0.1, 0.\bar 2) = 0.12\overline{02}$, etc.
 
     Every real number can be written with two digit representations, one with trailing 9's and one without.
     However $g(x, y) = 0.d_1d_2\dots\bar9$ is impossible since it would imply $x = 0.d_1\dots\bar9$ and $y = 0.d_2\dots\bar9$ but the definition of $g$ forbids this.


### PR DESCRIPTION
Changes to question solutions:

- I think 1.4.6a) should be not dense, for the same reason as 1.4.6c)
![image](https://user-images.githubusercontent.com/24727586/165885895-40220672-3d8f-4fa5-ba85-cb679f75242f.png)
- I think the argument for 1.4.8 b) falls under a fallacy around how the behaviour of the limit is not the same as the limit of the behaviour (or something like that) - I found a sequence of sets which I think meets the criteria:
![image](https://user-images.githubusercontent.com/24727586/165886159-d09fc7e4-c009-4a97-96f5-3d273da0a4a9.png)
![image](https://user-images.githubusercontent.com/24727586/165886250-3f5d0fad-4a57-45d9-bda6-29fe85c80509.png)

