### PR TITLE
Changes to 2.6

### DIFF
--- a/chapters/chapter2/chapter2-6.tex
+++ b/chapters/chapter2/chapter2-6.tex
@@ -24,10 +24,10 @@
 
 \begin{solution}
   \enum{
-  \item $x_n = (-1)^n/n$ is cauchy by Theorem 2.6.2.
-  \item Impossible since all cauchy sequences converge.
-  \item Impossible, If a subsequence was cauchy it would converge, implying the subsequence would be bounded and therefore the parent sequence would be bounded (because it is monotone) and thus would converge.
-  \item $(2, 1/2, 3, 1/3, \dots)$ has subsequence $(1/2, 1/3, \dots)$ which is cauchy.
+  \item $x_n = (-1)^n/n$ is Cauchy by Theorem 2.6.2.
+  \item Impossible since all Cauchy sequences converge.
+  \item Impossible, If a subsequence was Cauchy it would converge, implying the subsequence would be bounded and therefore the parent sequence would be bounded (because it is monotone) and thus would converge.
+  \item $(2, 1/2, 3, 1/3, \dots)$ has subsequence $(1/2, 1/3, \dots)$ which is Cauchy.
   }
 \end{solution}
 
@@ -69,8 +69,8 @@
 \begin{solution}
   \enum{
   \item Yes, since $|(a_n - b_n) - (a_m - b_m)| \le |a_n - a_m| + |b_m - b_n| < \epsilon/2 + \epsilon/2 = \epsilon$
-  \item No, if $a_n = 1$ then $(-1)^na_n$ diverges, and thus is not cauchy.
-  \item No, if $a_n = 1 - (-1)^n/n$ then $[[a_n]]$ fluctuates between $0$ and $1$ and so cannot be cauchy.
+  \item No, if $a_n = 1$ then $(-1)^na_n$ diverges, and thus is not Cauchy.
+  \item No, if $a_n = 1 - (-1)^n/n$ then $[[a_n]]$ fluctuates between $0$ and $1$ and so cannot be Cauchy.
   }
 \end{solution}
 
@@ -136,10 +136,10 @@
     Pick $K$ such that for $k \ge K$ we have $|x_{n_k} - x| < \epsilon$.
     Since $(x_n)$ is increasing and $x_n \le x$ every $n \ge n_K$ satisfies $|x_n - x| < \epsilon$ as well.
     Thus $(x_n)$ converges, completing the proof.
-  \item We're basically going to use the cauchy criterion as a replacement for NIP in the proof of BW.
-    Recall we had $I_{n+1} \subseteq I_n$ with $a_{n_k} \in I_k$, we will show $a_{n_k}$ is cauchy.
+  \item We're basically going to use the Cauchy criterion as a replacement for NIP in the proof of BW.
+    Recall we had $I_{n+1} \subseteq I_n$ with $a_{n_k} \in I_k$, we will show $a_{n_k}$ is Cauchy.
 
-    The length of $I_k$ is $M(1/2)^{k-1}$ by construction, so clearly $|a_{n_k} - a_{n_j}| < M(1/2)^{N-1}$ for $k,j \ge N$, implying $(a_{n_k})$ converges by the cauchy criterion.
+    The length of $I_k$ is $M(1/2)^{k-1}$ by construction, so clearly $|a_{n_k} - a_{n_j}| < M(1/2)^{N-1}$ for $k,j \ge N$, implying $(a_{n_k})$ converges by the Cauchy criterion.
 
     We needed the Archimedean Property to conclude $M(1/2)^{N-1} \in \mathbf{Q}$ can be made smaller then any $\epsilon \in \mathbf{R}^+$.
   \item The Archimedean Property is true for $\mathbf{Q}$ meaning it cannot prove AoC which is only true for $\mathbf{R}$. (If we did, then we would have proved AoC for $\mathbf{Q}$ which is obviously false.)

--- a/chapters/chapter2/chapter2-6.tex
+++ b/chapters/chapter2/chapter2-6.tex
@@ -68,7 +68,17 @@
 
 \begin{solution}
   \enum{
-  \item Yes, since $|(a_n - b_n) - (a_m - b_m)| \le |a_n - a_m| + |b_m - b_n| < \epsilon/2 + \epsilon/2 = \epsilon$
+  \item Yes. Note that by the Triangle Inequality, \[
+    |a_n - a_m| + |b_m - b_n| + |a_m - b_m|
+    \geq |a_n - b_n| \Rightarrow |a_n - a_m| + |b_m - b_n| \geq |a_n - b_n| - |b_m - a_m|
+  \]
+  and \[
+    |a_m - a_n| + |b_n - b_m| + |a_n - b_m|
+    \geq |a_m - b_m| \Rightarrow |a_n - a_m| + |b_m - b_n| \geq |a_m - b_m| - |b_n - a_n|
+  \]
+  therefore
+  \[ |c_n - c_m| = \big| |a_n - b_n| - |a_m - b_m| \big | \leq |a_n - a_m| + |b_m - b_n| < \epsilon/2 + \epsilon/2 = \epsilon\]
+
   \item No, if $a_n = 1$ then $(-1)^na_n$ diverges, and thus is not Cauchy.
   \item No, if $a_n = 1 - (-1)^n/n$ then $[[a_n]]$ fluctuates between $0$ and $1$ and so cannot be Cauchy.
   }

--- a/chapters/chapter2/chapter2-6.tex
+++ b/chapters/chapter2/chapter2-6.tex
@@ -25,8 +25,8 @@
 \begin{solution}
   \enum{
   \item $x_n = (-1)^n/n$ is Cauchy by Theorem 2.6.2.
-  \item Impossible since all Cauchy sequences converge.
-  \item Impossible, If a subsequence was Cauchy it would converge, implying the subsequence would be bounded and therefore the parent sequence would be bounded (because it is monotone) and thus would converge.
+  \item Impossible since all Cauchy sequences converge and are therefore bounded.
+  \item Impossible, if a subsequence was Cauchy it would converge, implying the subsequence would be bounded and therefore the parent sequence would be bounded (because it is monotone) and thus would converge.
   \item $(2, 1/2, 3, 1/3, \dots)$ has subsequence $(1/2, 1/3, \dots)$ which is Cauchy.
   }
 \end{solution}

--- a/chapters/chapter2/chapter2-7.tex
+++ b/chapters/chapter2/chapter2-7.tex
@@ -24,7 +24,7 @@
     $$
     |s_m - s_n| \le |s_m - s_N| + |s_N - s_n| < \epsilon/2 + \epsilon/2 = \epsilon
     $$
-    Which shows $(s_n)$ is cauchy, and hence converges by the Cauchy Criterion.
+    Which shows $(s_n)$ is Cauchy, and hence converges by the Cauchy Criterion.
   \item Let $I_1$ be the interval $[a_1 - a_2, a_1]$ and in general $I_n = [a_n - a_{n+1}, a_n]$, since $(a_n)$ is decreasing we have $I_{n+1} \subseteq I_n$. Applying the nested interval property gives
     $$\bigcap_{n=1}^\infty I_n \ne \emptyset$$
     Let $x \in \bigcap_{n=1}^\infty I_n$, since $a_n \in I_n$ and $x \in I_n$ the distance $|a_n - x|$ must be less then the length $|I_n|$. and since the length goes to zero $|a_n - x|$ can be made less then any $\epsilon$.
@@ -86,7 +86,7 @@
   Suppose $a_n, b_n \ge 0$, $a_n \le b_n$ and define $s_n = a_1 + \dots + a_n$, $t_n = b_1 + \dots + b_n$.
 
   \enum{
-  \item We have $|a_{m+1} + \dots + a_n| \le |b_{m+1} + \dots + b_n| < \epsilon$ implying $\sum_{n=1}^\infty a_n$ converges by the cauchy criterion.
+  \item We have $|a_{m+1} + \dots + a_n| \le |b_{m+1} + \dots + b_n| < \epsilon$ implying $\sum_{n=1}^\infty a_n$ converges by the Cauchy criterion.
     The other direction is analogous, if $(s_n)$ diverges then $(t_n)$ must also diverge since $s_n \le t_n$.
   \item Since $(t_n) \to t$. This implies that $s_n$ is bounded, and since $s_n \le t_n$ implies $s_n \le t$ by the order limit theorem, we can use the monotone convergence theorem to conclude $(s_n)$ converges.
   }
@@ -105,7 +105,7 @@
 \begin{solution}
   \enum{
   \item $x_n = 1/n$ and $y_n = 1/n$ have their respective series diverge, but $\sum x_ny_n = \sum 1/n^2$ converges since it is a p-series with $p > 1$.
-  \item Let $x_n = (-1)^n/n$ and $y_n = (-1)^n$. $\sum x_n$ converges but $\sum x_ny_n = \sum 1/n$ diverges. 
+  \item Let $x_n = (-1)^n/n$ and $y_n = (-1)^n$. $\sum x_n$ converges but $\sum x_ny_n = \sum 1/n$ diverges.
   \item Impossible as the algebraic limit theorem for series implies $\sum(x_n+y_n) - \sum x_n = \sum y_n$ converges.
   \item Impossible as the alternating series test implies it converges.
   }

--- a/chapters/chapter3/chapter3-2.tex
+++ b/chapters/chapter3/chapter3-2.tex
@@ -85,10 +85,10 @@
 \end{exercise}
 
 \begin{solution}
-  Let $F \subseteq \mathbf{R}$ be closed and suppose $(x_n)$ is a cauchy sequence in $F$, since cauchy sequences converge $(x_n) \to x$ and finally since $x \in F$ since $F$ contains its limit points.
+  Let $F \subseteq \mathbf{R}$ be closed and suppose $(x_n)$ is a Cauchy sequence in $F$, since Cauchy sequences converge $(x_n) \to x$ and finally since $x \in F$ since $F$ contains its limit points.
 
-  Now suppose every cauchy sequence $(x_n)$ in $F$ converges to a limit in $F$ and let $l$ be a limit point of $F$, as $l$ is a limit point of $F$ there exists a sequence $(y_n)$ in $F$ with $\lim(y_n) = l$.
-  since $(y_n)$ converges it must be cauchy, and since every cauchy sequence converges to a limit inside $F$ we have $l \in F$.
+  Now suppose every Cauchy sequence $(x_n)$ in $F$ converges to a limit in $F$ and let $l$ be a limit point of $F$, as $l$ is a limit point of $F$ there exists a sequence $(y_n)$ in $F$ with $\lim(y_n) = l$.
+  since $(y_n)$ converges it must be Cauchy, and since every Cauchy sequence converges to a limit inside $F$ we have $l \in F$.
 \end{solution}
 
 \begin{exercise}

--- a/chapters/chapter4/chapter4-3.tex
+++ b/chapters/chapter4/chapter4-3.tex
@@ -252,7 +252,7 @@
     \TODO
 
 
-    Note that showing $|y_n - y_{n-1}|$ goes to zero is not enough for general cauchy sequences, consider $a_n = \ln n$ as a counterexample: $|a_n - a_{n-1}| = \left|\ln(1 - 1/n)\right|$ goes to zero but $(a_n)$ is not cauchy.
+    Note that showing $|y_n - y_{n-1}|$ goes to zero is not enough for general Cauchy sequences, consider $a_n = \ln n$ as a counterexample: $|a_n - a_{n-1}| = \left|\ln(1 - 1/n)\right|$ goes to zero but $(a_n)$ is not Cauchy.
   \item \TODO
   \item \TODO
   }

--- a/chapters/chapter4/chapter4-4.tex
+++ b/chapters/chapter4/chapter4-4.tex
@@ -114,8 +114,8 @@
 \begin{solution}
   \enum{
   \item $f(x) = 1/x$ and $x_n = 1/n$ has $f(x_n)$ diverging, hence $f(x_n)$ is not Cauchy.
-  \item Impossible since for all $\epsilon > 0$ we can find an $N$ so that all $n \ge N$ has $|x_n - x_m| < \delta$ (since $x_n$ is cauchy) implying $|f(x_n) - f(x_m)| < \epsilon$ and thus $f(x_n)$ is Cauchy. (Uniform continuity is needed for the $\forall n \ge N$ part)
-  \item Impossible since $[0,\infty)$ is closed $(x_n) \to x \in [0,\infty)$ implying $f(x_n) \to f(x)$ since $f$ is continuous, thus $f(x_n)$ is a cauchy sequence.
+  \item Impossible since for all $\epsilon > 0$ we can find an $N$ so that all $n \ge N$ has $|x_n - x_m| < \delta$ (since $x_n$ is Cauchy) implying $|f(x_n) - f(x_m)| < \epsilon$ and thus $f(x_n)$ is Cauchy. (Uniform continuity is needed for the $\forall n \ge N$ part)
+  \item Impossible since $[0,\infty)$ is closed $(x_n) \to x \in [0,\infty)$ implying $f(x_n) \to f(x)$ since $f$ is continuous, thus $f(x_n)$ is a Cauchy sequence.
   }
 \end{solution}
 
@@ -239,7 +239,7 @@
 \end{exercise}
 
 \begin{solution}
-  A fact we'll use is that $g(A) \subseteq B$ if and only if $A \subseteq g^{-1}(B)$. Which is true since 
+  A fact we'll use is that $g(A) \subseteq B$ if and only if $A \subseteq g^{-1}(B)$. Which is true since
   $$
   g(A) \subseteq B \implies A \subseteq g^{-1}(g(A)) \subseteq g^{-1}(B)
   \quad\text{and}\quad
@@ -282,7 +282,7 @@
   \item Let $\epsilon > 0$ and set $N$ large enough that $n,m \ge N$ has $|x_n - x_m| < \delta$ implying $|f(x_n) - f(x_m)| < \epsilon$ by the uniformly continuity of $f$.
   \item Define $g(a) = \lim_{x \to a} g(x)$ and $g(b) = \lim_{x \to b} g(x)$ if both limits exist, then $g$ is continuous on $[a,b]$ meaning it is uniformly continuous on $[a,b]$ by Theorem 4.4.7, and thus is uniformly continuous the subset $(a,b)$.
 
-    If $f$ were uniformly continuous $(a,b)$ cauchy sequences are preserved meaning the sequential definition for functional limits (Theorem 4.2.3) implies the limits $\lim_{x \to a} g(x)$ and $\lim_{x \to b} g(x)$ exist.
+    If $f$ were uniformly continuous $(a,b)$ Cauchy sequences are preserved meaning the sequential definition for functional limits (Theorem 4.2.3) implies the limits $\lim_{x \to a} g(x)$ and $\lim_{x \to b} g(x)$ exist.
   }
 \end{solution}
 


### PR DESCRIPTION
Note: Apparently `\[ \]` and `\( \)` are preferred over `$$` and `$` in LaTeX - see https://tex.stackexchange.com/questions/503/why-is-preferable-to and https://tex.stackexchange.com/questions/510/are-and-preferable-to-dollar-signs-for-math-mode - so I'll be using those moving forward.

- Capitalized all instances of "Cauchy"
- I think you might've misread 2.6.4a) as `c_n = (a_n - b_n)`. (Incidentally my original proof was a bit of a mess, having two separate cases for `lim(a_n) = lim(b_n)` and  `lim(a_n) != lim(b_n)`, but it turns out that `||a_n - b_n| - |a_m - b_m|| \le |a_n - a_m| + |b_m - b_n|` anyways, although I think you have to jump through a few more hoops.
![image](https://user-images.githubusercontent.com/24727586/166134979-829e6aa3-3e5f-49d5-b558-18c050e8bf81.png)
