### PR TITLE
fix(1.5.7 (a)): `S` is two dimensional

### DIFF
--- a/chapters/chapter1/chapter1-5.tex
+++ b/chapters/chapter1/chapter1-5.tex
@@ -173,7 +173,7 @@
 
 \begin{solution}
   \enum{
-  \item We scale and shift up into the square. $f(x) = \frac 12 x + \frac 13$
+  \item We scale and shift up into the square. $f(x) = (\frac 12 x , \frac 13)$
   \item Let $g : S \to (0, 1)$ be a function that interleaves decimals in the representation without trailing nines, padding with zeros if necessary. $g(0.32, 0.45) = 0.3425$, $g(0.1\bar 9, 0.2) = g(0.2, 0.2) = 0.22$, $g(0.1, 0.23) = 0.1203$, $g(0.1, 0.\bar 2) = 0.12\overline{02}$, etc.
 
     Every real number can be written with two digit representations, one with trailing 9's and one without.


### PR DESCRIPTION
There is a typo in the solution probably
