### PR TITLE
Fix for issue #69, New proof of 2.5.2 (c)

### DIFF
--- a/chapters/chapter2/chapter2-5.tex
+++ b/chapters/chapter2/chapter2-5.tex
@@ -45,7 +45,10 @@
   \enum{
   \item True, removing the first term gives us the proper subsequence $(x_2, x_3, \dots)$ which converges. This implies $(x_1, x_2, \dots)$ also converges to the same value, since discarding the first term doesn't change the limit behavior of a sequence.
   \item True, as this is the contrapositive of "if a sequence converges then all subsequences converge (to the same limit)"
-  \item True, since $x_n$ is bounded $\lim \sup x_n$ and $\lim \inf x_n$ both converge. And since $x_n$ diverges Exercise \ref{ex:lim_sup} tells us $\lim \sup x_n \ne \lim \inf x_n$.
+  \item True. By the Bolzano--Weierstrass Theorem (BWT), the bounded sequence $(x_n)$ has a convergent subsequence. Let $(a_n)$ be such a subsequence with limit $a$, i.e., $a_n \to a$.
+  Since $(x_n)$ does not converge to $a$, there exists $\varepsilon > 0$ such that infinitely many terms of $(x_n)$ lie outside the interval $(a - \varepsilon, a + \varepsilon)$. Let $(b_n)$ be the sequence of those terms. As $(b_n)$ is bounded, BWT guarantees it has a convergent subsequence $(c_n)$ with limit $c$.
+  Since each term of $(c_n)$ lies outside the $\varepsilon$-neighborhood of $a$, it follows that $c \ne a$. 
+  Hence, $(x_n)$ has two subsequences that converge to different limits.
   \item True, The subsequence $(x_{n_k})$ converges meaning it is bounded $|x_{n_k}| \le M$. Suppose $(x_n)$ is increasing, then $x_n$ is bounded since picking $k$ so that $n_k > n$ we have $x_n \le x_{n_k} \le M$. A similar argument applies if $x_n$ is decreasing, therefore $x_n$ is monotonic bounded and so must converge.
   }
 \end{solution}


### PR DESCRIPTION
In the issue, I noticed an error in the proof. So, here is my new suggested proof for Ex. 2.5.2 (c).

Fixes #69 