### PR TITLE
Update chapter1-5.tex

### DIFF
--- a/chapters/chapter1/chapter1-5.tex
+++ b/chapters/chapter1/chapter1-5.tex
@@ -241,7 +241,7 @@
     Is countable (by \ref{ex:countable_union}), contradicting our assumption that $C \cap [0, 1]$ is uncountable.
   \item If $\alpha = 1$ then $C \cap [\alpha, 1]$ is finite. Now if $\alpha < 1$ we have $C \cap [\alpha+\epsilon, 1]$ countable for $\epsilon>0$ (otherwise the set would be in $A$, and hence $\alpha$ would not be an upper bound). Take
     $$
-    \bigcup_{n=1}^\infty C \cap [\alpha+1/n, 1] = C \cap [\alpha, 1]
+    \bigcup_{n=1}^\infty C \cap [\alpha+1/n, 1] = C \cap (\alpha, 1]
     $$
     Which is countable by \ref{ex:countable_union}.
   \item No, consider the set $C = \{1/n : n \in \mathbf{N}\}$ it has $C \cap [\alpha, 1]$ finite for every $\alpha$, but $C \cap [0, 1]$ is infinite.


### PR DESCRIPTION
Use of '[' where the interval should have '(' - does not affect the conclusion however as the cardinality of the set is unchanged by a single element.